### PR TITLE
Fix typo python31 -> python3

### DIFF
--- a/pyrtt-viewer
+++ b/pyrtt-viewer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python31
+#!/usr/bin/env python3
 # MIT License
 #
 # Copyright (c) 2018 Thomas Stenersen


### PR DESCRIPTION
Signed-off-by: Stenersen, Thomas <thomas.stenersen@nordicsemi.no>
